### PR TITLE
Stop using deprecated Buffer constructor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ $ npm install amp
 ## Example
 
 ```js
-var bin = amp.encode([new Buffer('hello'), new Buffer('world')]);
+var bin = amp.encode([Buffer.from('hello'), Buffer.from('world')]);
 var msg = amp.decode(bin);
 console.log(msg);
 ```

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -2,7 +2,7 @@
 var amp = require('..');
 
 suite('amp', function(){
-  var args = ['foo', 'bar', 'baz'].map(function(s){ return new Buffer(s); });
+  var args = ['foo', 'bar', 'baz'].map(function(s){ return Buffer.from(s); });
 
   bench('amp.encode()', function(){
     amp.encode(args);

--- a/examples/net.js
+++ b/examples/net.js
@@ -22,6 +22,6 @@ server.listen(3000);
 var client = net.connect(3000);
 
 setInterval(function(){
-  var msg = amp.encode([new Buffer('thumb'), new Buffer('image data here')]);
+  var msg = amp.encode([Buffer.from('thumb'), Buffer.from('image data here')]);
   client.write(msg);
 }, 100);

--- a/examples/stress.js
+++ b/examples/stress.js
@@ -21,7 +21,7 @@ server.listen(3000);
 
 var client = net.connect(3000);
 
-var msg = amp.encode([new Buffer('foo'), new Buffer('bar baz')]);
+var msg = amp.encode([Buffer.from('foo'), Buffer.from('bar baz')]);
 
 function next() {
   var n = 200;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -24,7 +24,7 @@ module.exports = function(args){
   }
 
   // buffer
-  var buf = new Buffer(len);
+  var buf = Buffer.allocUnsafe(len);
 
   // pack meta
   buf[off++] = version << 4 | argc;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -22,7 +22,7 @@ module.exports = Parser;
 function Parser(opts) {
   Stream.call(this, opts);
   this.state = 'message';
-  this._lenbuf = new Buffer(4);
+  this._lenbuf = Buffer.allocUnsafe(4);
 }
 
 /**
@@ -43,7 +43,7 @@ Parser.prototype._write = function(chunk, encoding, fn){
         this.version = meta >> 4;
         this.argv = meta & 0xf;
         this.state = 'arglen';
-        this._bufs = [new Buffer([meta])];
+        this._bufs = [Buffer.from([meta])];
         this._nargs = 0;
         this._leni = 0;
         break;
@@ -54,7 +54,7 @@ Parser.prototype._write = function(chunk, encoding, fn){
         // done
         if (4 == this._leni) {
           this._arglen = this._lenbuf.readUInt32BE(0);
-          var buf = new Buffer(4);
+          var buf = Buffer.allocUnsafe(4);
           buf[0] = this._lenbuf[0];
           buf[1] = this._lenbuf[1];
           buf[2] = this._lenbuf[2];

--- a/test/codec.js
+++ b/test/codec.js
@@ -10,7 +10,7 @@ describe('amp.encode(args...)', function(){
   })
 
   it('should support multiple args', function(){
-    var bin = amp.encode([new Buffer('hello'), new Buffer('world')]);
+    var bin = amp.encode([Buffer.from('hello'), Buffer.from('world')]);
     var msg = amp.decode(bin);
 
     msg.should.have.length(2);

--- a/test/stream.js
+++ b/test/stream.js
@@ -5,9 +5,9 @@ describe('amp.Stream', function(){
   it('should emit "data" events', function(done){
     var stream = new amp.Stream;
 
-    var a = amp.encode([new Buffer('tobi')]);
-    var b = amp.encode([new Buffer('loki'), new Buffer('abby')]);
-    var c = amp.encode([new Buffer('manny'), new Buffer('luna'), new Buffer('ewald')]);
+    var a = amp.encode([Buffer.from('tobi')]);
+    var b = amp.encode([Buffer.from('loki'), Buffer.from('abby')]);
+    var c = amp.encode([Buffer.from('manny'), Buffer.from('luna'), Buffer.from('ewald')]);
 
     var n = 0;
 
@@ -45,6 +45,6 @@ describe('amp.Stream', function(){
 
 function write(from, to) {
   for (var i = 0; i < from.length; i++) {
-    to.write(new Buffer([from[i]]));
+    to.write(Buffer.from([from[i]]));
   }
 }


### PR DESCRIPTION
The `new Buffer(string|number)` form was deemed an attack vector and deprecated. All Node.js v6.x+ versions have the `.from()`, `.alloc()` and `.allocUnsafe()` family of Buffer methods now.